### PR TITLE
fix typo in source-bucket lifecycle id suffix

### DIFF
--- a/source/cdk/lib/vod-stack.ts
+++ b/source/cdk/lib/vod-stack.ts
@@ -239,7 +239,7 @@ export class VideoOnDemand extends cdk.Stack {
       encryption: s3.BucketEncryption.S3_MANAGED,
       lifecycleRules: [
         {
-          id: `${cdk.Aws.STACK_NAME}-soure-archive`,
+          id: `${cdk.Aws.STACK_NAME}-source-archive`,
           tagFilters: {
             [cdk.Aws.STACK_NAME]: 'GLACIER'
           },

--- a/source/cdk/test/__snapshots__/vod.test.ts.snap
+++ b/source/cdk/test/__snapshots__/vod.test.ts.snap
@@ -4325,7 +4325,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                     {
                       Ref: AWS::StackName,
                     },
-                    -soure-archive,
+                    -source-archive,
                   ],
                 ],
               },


### PR DESCRIPTION
*Description of changes:*

This fixes a typo in the id suffix of the source-bucket lifecycle rule used when objects are tagged as GLACIER, along with a corresponding change to the test snapshot. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
