### PR TITLE
Release v6.1.17- Security updates for npm packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ codescan-unified-default.sh
 **/source/test
 **source/**/.coverage
 **source/**/coverage
+
+# Kiro IDE
+.kiro/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.17] - 2026-03-31
+
+### Security
+
+- Security updates for npm packages
+
 ## [6.1.16] - 2026-03-10
 
 ### Changed

--- a/solution-manifest.yaml
+++ b/solution-manifest.yaml
@@ -1,6 +1,6 @@
 id: SO9674
 name: video-on-demand-on-aws
-version: v6.1.16
+version: v6.1.17
 cloudformation_templates:
   - template: video-on-demand-on-aws.template
     main_template: true

--- a/source/archive-source/package-lock.json
+++ b/source/archive-source/package-lock.json
@@ -3545,6 +3545,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4479,6 +4486,16 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4638,15 +4655,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/cdk/package-lock.json
+++ b/source/cdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "video-on-demand-on-aws",
-  "version": "6.1.14",
+  "version": "6.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "video-on-demand-on-aws",
-      "version": "6.1.14",
+      "version": "6.1.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-solutions-constructs/aws-cloudfront-s3": "^2.85.2",

--- a/source/cdk/package.json
+++ b/source/cdk/package.json
@@ -2,7 +2,7 @@
   "name": "video-on-demand-on-aws",
   "description": "Synthesize templates for Video on Demand on AWS using AWS Cloud Development Kit (CDK).",
   "license": "Apache-2.0",
-  "version": "6.1.16",
+  "version": "6.1.17",
   "bin": {
     "cdk": "bin/vod.js"
   },

--- a/source/cdk/test/__snapshots__/vod.test.ts.snap
+++ b/source/cdk/test/__snapshots__/vod.test.ts.snap
@@ -36,7 +36,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
       ],
     },
   },
-  Description: (SO0021) - Video on Demand on AWS workflow with AWS Step Functions, MediaConvert, MediaPackage, S3, CloudFront and DynamoDB. Version %%VERSION%%,
+  Description: (SO9674) - Video on Demand on AWS workflow with AWS Step Functions, MediaConvert, MediaPackage, S3, CloudFront and DynamoDB. Version %%VERSION%%,
   Mappings: {
     AnonymizedData: {
       SendAnonymizedData: {
@@ -370,7 +370,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
             Arn,
           ],
         },
-        SolutionId: SO0021,
+        SolutionId: SO9674,
         Transcoder: MediaConvert,
         UUID: {
           Fn::GetAtt: [
@@ -434,7 +434,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 Arn,
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
           },
         },
         FunctionName: {
@@ -459,7 +459,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -585,7 +585,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -717,7 +717,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -796,7 +796,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Description: Used to deploy resources not supported by CloudFormation,
         Environment: {
           Variables: {
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
           },
         },
         FunctionName: {
@@ -821,7 +821,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 30,
@@ -1091,7 +1091,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -1150,7 +1150,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         VersioningConfiguration: {
@@ -1334,7 +1334,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -1392,7 +1392,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 Arn,
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
           },
         },
         FunctionName: {
@@ -1417,7 +1417,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -1535,7 +1535,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -1731,7 +1731,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 Arn,
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
           },
         },
         FunctionName: {
@@ -1756,7 +1756,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -1903,7 +1903,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -1977,7 +1977,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
             DynamoDBTable: {
               Ref: DynamoDBTable59784FC0,
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
             SnsTopic: {
               Ref: SnsTopic2C1570A4,
             },
@@ -2005,7 +2005,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -2125,7 +2125,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -2215,7 +2215,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -2395,7 +2395,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 },
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
             Source: {
               Ref: Source71E471F1,
             },
@@ -2426,7 +2426,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -2552,7 +2552,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -2613,7 +2613,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         VersioningConfiguration: {
@@ -2808,7 +2808,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -2892,7 +2892,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 Arn,
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
           },
         },
         FunctionName: {
@@ -2917,7 +2917,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -3043,7 +3043,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -3115,7 +3115,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 Arn,
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
           },
         },
         FunctionName: {
@@ -3140,7 +3140,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -3275,7 +3275,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -3413,7 +3413,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -3476,7 +3476,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 Arn,
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
           },
         },
         FunctionName: {
@@ -3501,7 +3501,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -3629,7 +3629,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -3705,7 +3705,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -3763,7 +3763,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 Arn,
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
           },
         },
         FunctionName: {
@@ -3788,7 +3788,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -3906,7 +3906,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -4010,7 +4010,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -4096,7 +4096,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 Arn,
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
             SnsTopic: {
               Ref: SnsTopic2C1570A4,
             },
@@ -4124,7 +4124,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -4244,7 +4244,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -4267,7 +4267,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -4390,7 +4390,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         VersioningConfiguration: {
@@ -4467,7 +4467,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         VisibilityTimeout: 120,
@@ -4504,7 +4504,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         VisibilityTimeout: 120,
@@ -4626,7 +4626,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 Arn,
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
             SqsQueue: {
               Ref: SqsQueue13597403,
             },
@@ -4654,7 +4654,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -4777,7 +4777,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -4903,7 +4903,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
                 ],
               ],
             },
-            SOLUTION_IDENTIFIER: AwsSolution/SO0021/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9674/%%VERSION%%,
           },
         },
         FunctionName: {
@@ -4928,7 +4928,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
         Timeout: 120,
@@ -5157,7 +5157,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },
@@ -5261,7 +5261,7 @@ exports[`VideoOnDemand Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0021,
+            Value: SO9674,
           },
         ],
       },

--- a/source/dynamo/package-lock.json
+++ b/source/dynamo/package-lock.json
@@ -3386,6 +3386,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4329,6 +4336,16 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4494,15 +4511,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/encode/package-lock.json
+++ b/source/encode/package-lock.json
@@ -3323,6 +3323,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4262,6 +4269,16 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4421,15 +4438,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/error-handler/package-lock.json
+++ b/source/error-handler/package-lock.json
@@ -3300,6 +3300,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4243,6 +4250,16 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4408,15 +4425,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/input-validate/package-lock.json
+++ b/source/input-validate/package-lock.json
@@ -3620,6 +3620,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4563,6 +4570,16 @@
         "type-detect": "4.0.8"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4722,15 +4739,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/media-package-assets/package-lock.json
+++ b/source/media-package-assets/package-lock.json
@@ -3319,6 +3319,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4253,6 +4260,16 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4412,15 +4429,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/output-validate/package-lock.json
+++ b/source/output-validate/package-lock.json
@@ -3743,6 +3743,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4695,6 +4702,16 @@
         "type-detect": "4.0.8"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4860,15 +4877,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/profiler/package-lock.json
+++ b/source/profiler/package-lock.json
@@ -3404,6 +3404,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4356,6 +4363,16 @@
         "type-detect": "4.0.8"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4521,15 +4538,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/sns-notification/package-lock.json
+++ b/source/sns-notification/package-lock.json
@@ -3319,6 +3319,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4253,6 +4260,16 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4412,15 +4429,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/sqs-publish/package-lock.json
+++ b/source/sqs-publish/package-lock.json
@@ -3349,6 +3349,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4283,6 +4290,16 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4442,15 +4459,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/source/step-functions/package-lock.json
+++ b/source/step-functions/package-lock.json
@@ -4543,6 +4543,13 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4716,16 +4723,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",


### PR DESCRIPTION
## [6.1.17] - 2026-03-31

### Security

- Security updates for npm packages

### Details

- Bumped version to 6.1.17 in `package.json`, `solution-manifest.yaml`, and `CHANGELOG.md`
- Refreshed npm dependencies across all 13 source packages
- Updated CDK snapshot (solution ID SO0021 → SO9674 from guidance migration)
- Added `.kiro/` to `.gitignore`
- All unit tests passing (CDK: 1/1, Lambda JS: all suites green, Python mediainfo: 10/10)
