### PR TITLE
Restore Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # npm dependencies across all Lambda/CDK packages under source/
+  - package-ecosystem: "npm"
+    directories:
+      - "/source/*"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions workflow dependencies (ready for when workflows are added)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Re-adds `.github/dependabot.yml`, which had been removed from the repository. Its absence caused two problems:

1. **Dependabot was paused** due to inactivity.
2. Existing Dependabot PRs (#237, #241) **could not be rebased** — Dependabot reported the `dependabot.yml` entry that created them no longer exists.

## Changes

- `npm` ecosystem entry using the `directories: ["/source/*"]` glob to cover all 13 Lambda/CDK packages under `source/` (there is no root `package.json`).
- `github-actions` ecosystem entry, ready for when workflow files are added under `.github/workflows/`.
- Weekly schedule, PR limit of 10 per ecosystem.

## Follow-up after merge

Once merged, close the stale PRs #237 and #241 so Dependabot re-scans against this config and opens current PRs (the repo currently shows 23 open vulnerability alerts).