### PR TITLE
Restore Dependabot configuration (monthly schedule)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # npm dependencies across all Lambda/CDK packages under source/
+  - package-ecosystem: "npm"
+    directories:
+      - "/source/*"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions workflow dependencies (ready for when workflows are added)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Re-adds `.github/dependabot.yml`, which had been removed from the repository. Its absence caused Dependabot to pause and prevented existing Dependabot PRs (#237, #241) from being rebased.

Supersedes #262 — that branch could not be updated in place because the branch protection ruleset requires all changes to an existing branch to go through a PR, so this replacement branch carries the requested change from the start.

## Changes

- `npm` ecosystem entry using `directories: ["/source/*"]` to cover all 13 Lambda/CDK packages under `source/` (there is no root `package.json`).
- `github-actions` ecosystem entry, ready for when workflow files are added.
- **Monthly** schedule (per @afayle's review feedback on #262, to minimise management overhead), PR limit of 10 per ecosystem.

## Follow-up after merge

Once merged, close the stale PRs #237 and #241 so Dependabot re-scans against this config and opens current PRs (the repo currently shows 23 open vulnerability alerts).